### PR TITLE
Fix double semicolon in Auth login view

### DIFF
--- a/application/controllers/Auth.php
+++ b/application/controllers/Auth.php
@@ -13,7 +13,7 @@ class Auth extends CI_Controller {
         if ($this->session->userdata('user')) {
             redirect('dashboard');
         }
-        $this->load->view('auth/login' , ['page_title' => 'Login']);;
+        $this->load->view('auth/login', ['page_title' => 'Login']);
     }
 
     public function login_submit()


### PR DESCRIPTION
## Summary
- correct `Auth` controller login view load statement

## Testing
- `php -l application/controllers/Auth.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b67c08b38832bb6bd6023f691559e