### PR TITLE
Add PHPUnit tests and config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ user_guide_src/cilexer/pycilexer.egg-info/*
 *.sublime-project
 /tests/tests/
 /tests/results/
+tests/.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -16,11 +16,12 @@
 	"suggest": {
 		"paragonie/random_compat": "Provides better randomness in PHP 5.x"
 	},
-	"scripts": {
-		"test:coverage": [
-			"@putenv XDEBUG_MODE=coverage",
-			"phpunit --color=always --coverage-text --configuration tests/travis/sqlite.phpunit.xml"
-		],
+        "scripts": {
+                "test": "vendor/bin/phpunit --configuration tests/phpunit.xml",
+                "test:coverage": [
+                        "@putenv XDEBUG_MODE=coverage",
+                        "phpunit --color=always --coverage-text --configuration tests/travis/sqlite.phpunit.xml"
+                ],
 		"post-install-cmd": [
 			"sed -i s/name{0}/name[0]/ vendor/mikey179/vfsstream/src/main/php/org/bovigo/vfs/vfsStream.php"
 		],

--- a/tests/MCaseTest.php
+++ b/tests/MCaseTest.php
@@ -1,0 +1,25 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class MCaseTest extends TestCase
+{
+    /** @var M_case */
+    private $model;
+
+    protected function setUp(): void
+    {
+        $this->model = new M_case();
+        $db = get_instance()->db;
+        $db->query('CREATE TABLE cases (id INTEGER PRIMARY KEY AUTOINCREMENT, confirmed INTEGER, recovered INTEGER, deaths INTEGER, suspected INTEGER);');
+    }
+
+    public function testSumColumnReturnsCorrectValue()
+    {
+        $db = get_instance()->db;
+        $db->insert('cases', ['confirmed' => 1, 'recovered' => 0, 'deaths' => 0, 'suspected' => 0]);
+        $db->insert('cases', ['confirmed' => 2, 'recovered' => 0, 'deaths' => 0, 'suspected' => 0]);
+
+        $sum = $this->model->sumColumn('confirmed');
+        $this->assertSame(3, $sum);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,54 @@
+<?php
+// Set BASEPATH for CodeIgniter core
+define('BASEPATH', __DIR__ . '/../system/');
+
+// Minimal stubs for CI helper functions used by the DB layer
+if (!function_exists('log_message')) {
+    function log_message($level, $message)
+    {
+        // no-op during testing
+    }
+}
+
+if (!function_exists('show_error')) {
+    function show_error($message, $status_code = 500, $heading = 'Error')
+    {
+        throw new Exception($message, $status_code);
+    }
+}
+
+require_once BASEPATH . 'core/Model.php';
+require_once BASEPATH . 'database/DB.php';
+
+// Provide get_instance() for CI_Model
+function &get_instance()
+{
+    return CI_Test::$ci;
+}
+
+class CI_Test
+{
+    public static $ci;
+
+    public static function init()
+    {
+        // configuration for in-memory sqlite
+        $config = [
+            'dsn'      => 'sqlite::memory:',
+            'dbdriver' => 'sqlite3',
+            'database' => ':memory:',
+            'db_debug' => true,
+            'char_set' => 'utf8',
+            'dbcollat' => 'utf8_general_ci',
+            'cachedir' => '',
+            'save_queries' => true,
+        ];
+
+        self::$ci = new stdClass();
+        self::$ci->db = DB($config, true);
+    }
+}
+
+CI_Test::init();
+
+require_once __DIR__ . '/../application/models/M_case.php';

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="bootstrap.php" colors="true">
+    <testsuites>
+        <testsuite name="Geosehat Test Suite">
+            <directory suffix="Test.php">.</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>


### PR DESCRIPTION
## Summary
- add PHPUnit configuration in `tests` folder
- add bootstrap script for simple CodeIgniter DB setup
- test M_case::sumColumn with SQLite
- enable `composer test` script

## Testing
- `vendor/bin/phpunit --configuration tests/phpunit.xml --colors=never`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_685b67c37524832b86f782f1eb09048f