### PR TITLE
Fix closing brace in register

### DIFF
--- a/application/controllers/Auth.php
+++ b/application/controllers/Auth.php
@@ -53,7 +53,8 @@ class Auth extends CI_Controller {
         }
 
         $this->load->view('auth/register',['page_title' => 'Register']);
-        }
+
+    }
 
     public function register_submit()
     {


### PR DESCRIPTION
## Summary
- remove stray closing brace line to properly end `register()` before `register_submit()`

## Testing
- `php -l application/controllers/Auth.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b67c27b08832b9f6f04de84dfa727